### PR TITLE
Add more mathjax packages

### DIFF
--- a/src/mathjax/mathJaxConfig.ts
+++ b/src/mathjax/mathJaxConfig.ts
@@ -1,7 +1,39 @@
 //TODO: use AMS numbering once the package will be available
+
 const MathJaxConfig = {
     TeX: {
-        packages: ['base', 'ams', 'boldsymbol', 'newcommand', 'unicode', 'color', 'mhchem', 'enclose'], // extensions to use
+        packages: [
+            'base',
+            'action',
+            'ams',
+            'amscd',
+            'bbox',
+            'boldsymbol',
+            'braket',
+            'bussproofs',
+            'cancel',
+            'cases',
+            'centernot',
+            'color',
+            'colortbl',
+            'empheq',
+            'enclose',
+            'extpfeil',
+            'gensymb',
+            'html',
+            'mathtools',
+            'mhchem',
+            'newcommand',
+            //'noerrors',
+            //'noundefined',
+            'upgreek',
+            'unicode',
+            'verb',
+            'configmacros',
+            'tagformat',
+            'textcomp',
+            'textmacros'
+        ],
         tagSide: "right", // side for \tag macros
         tagIndent: "0.8em", // amount to indent tags
         multlineWidth: "100%", // width of multline environment


### PR DESCRIPTION
First of all, thank you for the great project. I am enjoying writing academic documents :)

In my community, we use a special package to write scientific and technical documents, and MathJax is fortunate enough to support it, so I wanted to use it in this project. Also, since this is likely to be the case in various communities, I've added the possible packages as long as they don't cause errors in testing. If it is possible, could you please consider adding the feature?

Honestly, I just want to use amscd and bussproofs in Mathpix.

Thank you very much.