### PR TITLE
PR into master from dev/olga/circleci-fix-install-dependency-failed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,5 +87,5 @@ workflows:
     - deploy-feature:
         filters:
           branches:
-            only:
-            - feature
+            ignore:
+            - master

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "chai": "^4.2.0",
     "copy-to-clipboard": "^3.3.1",
     "deepmerge": "^4.2.2",
-    "domino": "Mathpix/domino",
+    "domino": "https://github.com/Mathpix/domino.git",
     "highlight.js": "^10.4.1",
     "htmlparser2": "^4.1.0",
     "is-plain-object": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1975,9 +1975,9 @@ domhandler@^4.2.0:
   dependencies:
     domelementtype "^2.2.0"
 
-domino@Mathpix/domino:
+"domino@https://github.com/Mathpix/domino.git":
   version "2.1.6"
-  resolved "https://codeload.github.com/Mathpix/domino/tar.gz/30ec7627c22dbecf0e77141d48c4da629d54b850"
+  resolved "https://github.com/Mathpix/domino.git#30ec7627c22dbecf0e77141d48c4da629d54b850"
 
 domutils@^2.0.0:
   version "2.8.0"


### PR DESCRIPTION
branch:  dev/olga/circleci-fix-install-dependency-failed

### Why:

Fixes CiclreCi error:
https://app.circleci.com/pipelines/github/Mathpix/mathpix-markdown-it/759/workflows/a635df23-f070-49a0-a04f-401e6b1c2bb0/jobs/326


### What's being changed:

- Updated domino dependency to fix CircleCI error https://app.circleci.com/pipelines/github/Mathpix/mathpix-markdown-it/759/workflows/a635df23-f070-49a0-a04f-401e6b1c2bb0/jobs/326

<img width="1346" alt="Screen Shot 2023-07-03 at 19 13 48" src="https://github.com/Mathpix/mathpix-markdown-it/assets/32493105/af47dd34-0c6d-4555-bc78-7ca593aa529f">

- Added execution of CircleCI tests for all branches

https://app.circleci.com/pipelines/github/Mathpix/mathpix-markdown-it/766/workflows/12b48220-8add-4c0c-91de-699fdd320a64/jobs/333
