### PR TITLE
Add 'bbox' extension to MathJax configuration

### DIFF
--- a/src/mathjax/mathJaxConfig.ts
+++ b/src/mathjax/mathJaxConfig.ts
@@ -3,7 +3,7 @@ const MathJaxConfig = {
     TeX: {
         packages: ['base', 'ams', 'boldsymbol', 'html', 'newcommand', 'unicode', 'color', 'mhchem', 'enclose', 'extpfeil', 'empheq', 'cases',
             'cancel',
-            'fix-unicode', 'icon'], // extensions to use
+            'fix-unicode', 'icon', 'bbox'], // extensions to use
         tagSide: "right", // side for \tag macros
         tagIndent: "0.8em", // amount to indent tags
         multlineWidth: "100%", // width of multline environment


### PR DESCRIPTION
Added `\bbox` command support for mathjax latex equations.

## Problem

The `\bbox[5px,border: 2px solid]{12}` LaTeX syntax throws an "Undefined control sequence" error when rendering math with MathJax.

**Error:**

```
[TexConvert] ERROR=> {
  "message": "TeX error: Undefined control sequence \\bbox",
  "latex": "\\bbox[5px,border: 2px solid]{12}"
}
```

## Solution

The `bbox` package needs to be added to the MathJax configuration to enable support for the `\bbox` command.

## Changes

- Added `'bbox'` to the packages array in `src/mathjax/mathJaxConfig.ts`

## Testing

- Locally tested: `\bbox[5px,border: 2px solid]{12}` now renders correctly after build.